### PR TITLE
Return modified data from prepare functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next
+
+- Fixed `prepare` wrapper to return modified data (#14)
+
 ## 2.0.0-beta.12 (31-03-2021)
 
 - Bumped `esbuild` to 0.11.2 and simplified bundling

--- a/lib/shared/bundle.js
+++ b/lib/shared/bundle.js
@@ -50,6 +50,7 @@ function prepare(modelConfig) {
             '            for (const prepare of prepares) {',
             '                data = prepare(data, ...args) || data;',
             '            }',
+            '            return data;',
             '        });',
             '    }',
             '}'


### PR DESCRIPTION
Without this change, prepare functions can only mutate the data, the return value will not be used.

Tested this locally, looks like adding this line was enough to make it work